### PR TITLE
Github action with Linux support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,11 +13,6 @@ on:
     inputs:
       version:
         description: Version
-      env:
-        description: Environment
-        type: environment
-        required: true
-        default: "Production"
 
 jobs:
   build:
@@ -29,19 +24,13 @@ jobs:
             architecture: x64
             artifact: windows
             upload_path_suffix: '/*'
-          - name: MacOS Build
-            os: macos-latest
-            architecture: x64
-            artifact: macos
-            upload_path_suffix: '.zip'
           - name: Linux Build
-            os: ubuntu-20.04
+            os: ubuntu-latest
             architecture: x64
             artifact: linux
             upload_path_suffix: '/*'
     
     runs-on: ${{ matrix.os }}
-    environment: ${{ github.event.inputs.env || 'Development' }}
     
     defaults:
       run:
@@ -52,17 +41,13 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.15
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
+          ref: archipelago
           submodules: recursive
-      - name: Add keys
-        run: |
-            echo "$SEED_KEY" > keys/seed_key.py
-        env:
-          SEED_KEY: ${{ secrets.SEED_KEY }}
       - name: Set up Python
         id: setup-py
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           check-latest: true
@@ -70,7 +55,7 @@ jobs:
           cache: 'pip' # Cache all pip dependency downloads
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./.venv
           key: ${{ runner.os }}-venv-${{ steps.setup-py.outputs.python-version  }}-${{ hashFiles('**/requirements*.txt') }}
@@ -109,7 +94,7 @@ jobs:
       - name: Bundle Python App
         run: python build.py
       - name: Upload Python App
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wwrando-${{ steps.vars.outputs.full_version }}-${{ matrix.artifact }}-${{ matrix.architecture }}
           path: dist/release_archive_${{ steps.vars.outputs.full_version }}_${{ matrix.architecture }}${{ matrix.upload_path_suffix }}


### PR DESCRIPTION
Those are the github action settings I've used to get things working under linux.

I ended up removing `Add keys` step, but I can just add it back if you ended up setting it up in your environment
I also removed the `Environment` workflow input (and job configuration), but once again I can add them back if you ended up setting some environments.
Finally I removed the MacOS build, but it's mostly since I can't test it, and I assume you can't either.

If those settings are good with you, try running the action and send the linux build my way, I'll make sure it still works properly.
